### PR TITLE
Fix main menu button sometimes turning into a white square

### DIFF
--- a/common/src/main/java/com/mallowigi/icons/svgpatchers/MainSvgPatcher.kt
+++ b/common/src/main/java/com/mallowigi/icons/svgpatchers/MainSvgPatcher.kt
@@ -30,6 +30,7 @@ import com.intellij.ui.svg.SvgAttributePatcher
 import com.intellij.util.SVGLoader
 import com.intellij.util.SVGLoader.SvgElementColorPatcherProvider
 import com.mallowigi.utils.getValue
+import org.jetbrains.annotations.NonNls
 import java.util.*
 
 /**
@@ -49,6 +50,12 @@ class MainSvgPatcher : SvgElementColorPatcherProvider {
     CustomColorPatcher(),
   )
 
+  @NonNls
+  private val IGNORED_PATHS = setOf(
+    "expui/general/windowsMenu@20x20.svg",
+    "expui/general/windowsMenu@20x20_dark.svg",
+  )
+
   /**
    * Add patcher to the OtherPatcher
    *
@@ -66,7 +73,13 @@ class MainSvgPatcher : SvgElementColorPatcherProvider {
   }
 
   /** Create patcher for path. */
-  override fun attributeForPath(path: String): SvgAttributePatcher = createPatcher()
+  override fun attributeForPath(path: String): SvgAttributePatcher? {
+    if (IGNORED_PATHS.contains(path)) {
+      return null
+    }
+
+    return createPatcher()
+  }
 
   private fun createPatcher(): SvgAttributePatcher = object : SvgAttributePatcher {
     override fun patchColors(attributes: MutableMap<String, String>) {


### PR DESCRIPTION
Added a ignore list for the main menu SVGs.

#### Description
This is done by adding the "windowsMenu@20x20" to ignored paths for the `MainSvgPatcher`.
The main problem is in the `BigIconsPatcher` which messes the icon up when used,
but we cannot easily disable just that one patcher for it. We can only disable all the patchers instead.
However, this isn't as bad as it sounds, since currently none of the patchers affect the icon anyway
(it is already in grayscale and the size isn't affected when the settings change).

This is also hard to test for, since the IDE appears to have some internal cache for the icons, so old changed icons sometimes will appear not fixed on the old version or not broken on the old version.
The easiest way I found to test it was to put custom icon size to 24 and custom line height to 50.
Then I went down one line height at a time on the new version and compared that with going down one line height from 40 on the old version.
That way there is no internal icon cache, and it can be observed that after this fix the icon stays as it should, instead of turning to a white square.


#### Motivation and Context
Fixes https://github.com/AtomMaterialUI/a-file-icon-idea/issues/481

#### Screenshots (if appropriate):
before:
<img width="837" height="713" alt="before" src="https://github.com/user-attachments/assets/b9652c84-2a94-4966-aced-a6d6202b7650" />
after:
<img width="837" height="713" alt="after" src="https://github.com/user-attachments/assets/d0d27293-fc45-4a69-9cef-bc779e3ddf4a" />

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [ ] I updated the version.
- [ ] I updated the changelog with the new functionality.

### Note
I **did not** update the changelog/version this time, since I was not sure about the versioning (it is technically a fix, but previous performance fix was also a fix but changed the version to 102.0.0)
Due to this IDE cache this will also not immediately fix the issue for people that currently have this problem.

My one solution I tried which worked for old would be to change the order in `BigIconsPatcher::digest()` which will preserve the exact same settings/heuristic while being unique for everyone on the new version, therefore forcing a refresh and fixing the issue for everyone. To test it:
- install old version
- change to some icon size/line height which displays white square
- install new version
If the new version has the digest re-ordered, it will display correctly. Otherwise it won't until you change the icon size/line height.

Let me know if I should add this workaround, or if maybe you have some better idea how to approach this problem.